### PR TITLE
power_engine: fix seclabel by setting it to thermal-engine

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -604,7 +604,7 @@ service power_engine /system/bin/power_engine
     user root
     group root
     disabled
-    seclabel u:r:power_engine:s0
+    seclabel u:r:thermal-engine:s0
 
 on property:persist.sys.power_ctrl=1
     start power_engine


### PR DESCRIPTION
This change is needed due to
https://github.com/IDOL-3/android_device_alcatel_idol3/commit/233049d42e2cbb358d97f48263a8510a0d4ff9b6

Change-Id: I4748eb5b5030a37c67005eae01c8bbb9c5964e51